### PR TITLE
Enable Language and Locale module, add German language, and enable URL detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Backdrop 4 Good website.
 Spin up Project on Lando
 ---------------
 
-* `git clone git@github.com:BackdropForGood/backdrop4good.org.git`
-* `cd backdropforgood.org`
+* `git clone git@github.com:Backdrop4Good/backdrop4good.org.git`
+* `cd backdrop4good.org`
 * Add in a `settings.php` to the `web` directory. The file that points to the
   config (which is outside of the `web` directory).
   * `wget https://github.com/backdrop/backdrop/raw/1.x/settings.php`

--- a/config/staging/language.settings.json
+++ b/config/staging/language.settings.json
@@ -1,0 +1,26 @@
+{
+    "_config_name": "language.settings",
+    "_config_static": true,
+    "language_negotiation": {
+        "language": [
+            "locale-url",
+            "language-default"
+        ]
+    },
+    "languages": {
+        "en": {
+            "langcode": "en",
+            "name": "English",
+            "direction": 0,
+            "enabled": true,
+            "weight": 0
+        },
+        "de": {
+            "langcode": "de",
+            "name": "German",
+            "direction": 0,
+            "enabled": true,
+            "weight": 0
+        }
+    }
+}

--- a/config/staging/locale.settings.json
+++ b/config/staging/locale.settings.json
@@ -1,0 +1,18 @@
+{
+    "_config_name": "locale.settings",
+    "cache_length": 75,
+    "field_language_fallback": true,
+    "language_negotiation_session_parameter": "language",
+    "language_negotiation_url_part": "path_prefix",
+    "language_negotiation_url_prefixes": {
+        "en": "",
+        "de": "de"
+    },
+    "language_negotiation_url_type": "language",
+    "language_negotiation_url_domains": {
+        "en": "",
+        "de": ""
+    },
+    "language_providers_weight_language": [],
+    "translate_english": false
+}

--- a/config/staging/system.core.json
+++ b/config/staging/system.core.json
@@ -28,7 +28,7 @@
     "image_jpeg_quality": "75",
     "image_style_flood_limit": 5,
     "install_profile": "standard",
-    "language_count": 1,
+    "language_count": 2,
     "language_default": "en",
     "log_row_limit": 1000,
     "log_identity": "backdrop",

--- a/config/staging/user.role.administrator.json
+++ b/config/staging/user.role.administrator.json
@@ -95,6 +95,8 @@
         "access backup files",
         "delete backup files",
         "restore from backup",
-        "administer backup and migrate"
+        "administer backup and migrate",
+        "administer languages",
+        "translate interface"
     ]
 }


### PR DESCRIPTION
Fixes https://github.com/Backdrop4Good/backdrop4good.org/issues/21

---

- Enabled module: Language  
(Lets you configure a number of languages to be used on your website.)
- Added language: German (admin/config/regional/language)
- Enabled module: Locale  
(Provides language negotiation functionality and user interface translation to languages other than English.)
- Configured language detection and selection (admin/config/regional/language/detection): Enable URL method (Determine the language from the URL)

Additional changes (maybe not directly visible in code):

- Downloaded the Drupal 7 core German language file from http://ftp.drupal.org/files/translations/7.x/drupal/drupal-7.56.de.po.
- Import the language file on admin/config/regional/translate/import.  
Result: There are 4700 newly created translated strings.
- Get and import more German language files from Drupal modules which are in Backdrop core. URL: https://localize.drupal.org/download?project=MODULE-NAME
  - CKEditor, 214 strings
  - Date, 390 strings
  - Email, 19 strings
  - Link, 50 strings
  - Pathauto, 147 strings
  - Redirect, 35 strings
  - Token, 117 strings
  - Views, 1642 strings