### PR TITLE
Add Spanish language, import Spanish language files

### DIFF
--- a/config/staging/language.settings.json
+++ b/config/staging/language.settings.json
@@ -21,6 +21,13 @@
             "direction": 0,
             "enabled": true,
             "weight": 0
+        },
+        "es": {
+            "langcode": "es",
+            "name": "Spanish",
+            "direction": 0,
+            "enabled": true,
+            "weight": 0
         }
     }
 }

--- a/config/staging/locale.settings.json
+++ b/config/staging/locale.settings.json
@@ -6,12 +6,14 @@
     "language_negotiation_url_part": "path_prefix",
     "language_negotiation_url_prefixes": {
         "en": "",
-        "de": "de"
+        "de": "de",
+        "es": "es"
     },
     "language_negotiation_url_type": "language",
     "language_negotiation_url_domains": {
         "en": "",
-        "de": ""
+        "de": "",
+        "es": ""
     },
     "language_providers_weight_language": [],
     "translate_english": false

--- a/config/staging/system.core.json
+++ b/config/staging/system.core.json
@@ -28,7 +28,7 @@
     "image_jpeg_quality": "75",
     "image_style_flood_limit": 5,
     "install_profile": "standard",
-    "language_count": 2,
+    "language_count": 3,
     "language_default": "en",
     "log_row_limit": 1000,
     "log_identity": "backdrop",


### PR DESCRIPTION
Fixes https://github.com/Backdrop4Good/backdrop4good.org/issues/19#issuecomment-340112976.

The PR holds configuration files for the addition of Spanish language. (I guess the imported language files with the Spanish strings have to be imported via the database or via the UI.)