### PR TITLE
Add French language

### DIFF
--- a/config/staging/language.settings.json
+++ b/config/staging/language.settings.json
@@ -28,6 +28,13 @@
             "direction": 0,
             "enabled": true,
             "weight": 0
+        },
+        "fr": {
+            "langcode": "fr",
+            "name": "French",
+            "direction": 0,
+            "enabled": true,
+            "weight": 0
         }
     }
 }

--- a/config/staging/locale.settings.json
+++ b/config/staging/locale.settings.json
@@ -7,13 +7,15 @@
     "language_negotiation_url_prefixes": {
         "en": "",
         "de": "de",
-        "es": "es"
+        "es": "es",
+        "fr": "fr"
     },
     "language_negotiation_url_type": "language",
     "language_negotiation_url_domains": {
         "en": "",
         "de": "",
-        "es": ""
+        "es": "",
+        "fr": ""
     },
     "language_providers_weight_language": [],
     "translate_english": false

--- a/config/staging/system.core.json
+++ b/config/staging/system.core.json
@@ -28,7 +28,7 @@
     "image_jpeg_quality": "75",
     "image_style_flood_limit": 5,
     "install_profile": "standard",
-    "language_count": 3,
+    "language_count": 4,
     "language_default": "en",
     "log_row_limit": 1000,
     "log_identity": "backdrop",


### PR DESCRIPTION
Fixes https://github.com/Backdrop4Good/backdrop4good.org/issues/19#issuecomment-343677294.

The PR holds the configuration files for the addition of French language.

(The `.po` files with French language strings have to be imported later via the backend of the site.)